### PR TITLE
Update vzlogger_conf_example.jsonc

### DIFF
--- a/vzlogger_conf_example.jsonc
+++ b/vzlogger_conf_example.jsonc
@@ -11,19 +11,23 @@
     "channels": [
         {
             "identifier": "powerac",
+            "middleware": "http://localhost/middleware.php",
             "uuid": "<replace with your uuid>"
         },
         {
             "identifier": "powerdc1",
+            "middleware": "http://localhost/middleware.php",
             "uuid": "<replace with your uuid>"
         },
         {
             "identifier": "powerdc2",
+            "middleware": "http://localhost/middleware.php",
             "uuid": "<replace with your uuid>"
         },
         {
             "identifier": "temp",
+            "middleware": "http://localhost/middleware.php",
             "uuid": "<replace with your uuid>"
         }
-    ]
-}
+    ] // channels
+} // meter


### PR DESCRIPTION
- Added "middleware" for each channel. Reason: Without the "middleware" lines vzlogger throws an error.
- Added some comments to increase the oversight.